### PR TITLE
Removed git checkout step from Dockerfil

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,6 @@ RUN set -ex \
     && adduser --disabled-password --gecos '' mush \
     && mkdir -p /mush && chown mush.mush /mush \
     && su -c 'git clone https://github.com/pennmush/pennmush.git /mush' mush \
-    && su -c 'cd /mush && git checkout ${pennmush_version}' mush \
     && su -c 'cd /mush \
         && \
         CFLAGS=-Wno-pragmas \


### PR DESCRIPTION
Removed line 77 of Docker file

## Description
Removed git checkout step from Dockerfile

## Motivation and Context
The git repo containing the mush codebase has recently had a merge from a feature branch so this checkout is no longer needed. This fixes a problem with an incorrect URL for pcre2

## How Has This Been Tested?
I have tested it locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
